### PR TITLE
Bump template version in SNS message

### DIFF
--- a/message.json
+++ b/message.json
@@ -9,7 +9,7 @@
     "ActionType": "AWSConfigActivation",
     "AWSAccountId": "${account_id}",
     "ExternalId": "${external_id}",
-    "TemplateVersion": "1.4",
+    "TemplateVersion": "1.5",
     "Type": "AWS_CT_CFG",
     "CrossAccountRoleArn": "${role_arn}",
     "CustomerName": "${customer_name}",

--- a/outputs.tf
+++ b/outputs.tf
@@ -10,5 +10,5 @@ output "customer_name" {
 
 output "template_version" {
   description = "Bridgecrew.io template version."
-  value       = "1.0"
+  value       = "1.5"
 }


### PR DESCRIPTION
The version still showed 1.4 (and the output version 1.0). This causes users to get notifications in the app to upgrade, even after they've upgraded.