### PR TITLE
feat: add iam role name optional variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ No Modules.
 | common\_tags | Implements the common tags scheme | `map(any)` | <pre>{<br>  "integration": "bridgecrew-aws-readonly",<br>  "module": "terraform-aws-bridgecrew-read-only"<br>}</pre> | no |
 | org\_name | The name of the company the integration is for. Must be alphanumeric. | `string` | n/a | yes |
 | topic\_name | The name of the SNS topic for Bridgecrew to receive notifications. This value should not typically be modified, but is provided here to support testing and troubleshooting, if needed. | `string` | `"handle-customer-actions"` | no |
+| role\_name | The name of the read-only IAM role to be created. Default will be calculated depending on org\_name and account\_alias being set. Useful to set this if the calculated name is too large i.e. larger than 64 chars which results in an error. | `string` | `""` | no |
+
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 locals {
   resource_name_prefix = var.account_alias == "" ? "${var.org_name}-bc" : "${var.org_name}-${var.account_alias}"
-  role_name            = "${local.resource_name_prefix}-read-bridgecrewcwssarole"
+  role_name            = var.role_name != null ? var.role_name : "${local.resource_name_prefix}-read-bridgecrewcwssarole"
   profile_str          = var.aws_profile != null ? "--profile ${var.aws_profile}" : ""
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -28,16 +28,20 @@ variable "common_tags" {
   }
 }
 
-
 variable "topic_name" {
   type        = string
   default     = "handle-customer-actions"
   description = "The name of the SNS topic for Bridgecrew to receive notifications. This value should not typically be modified, but is provided here to support testing and troubleshooting, if needed."
 }
 
-
 variable "bridgecrew_account_id" {
   type        = string
   default     = "890234264427"
   description = "The Bridgecrew AWS account ID from which scans will originate. This value should not typically be modified, but is provided here to support testing and troubleshooting, if needed."
+}
+
+variable "role_name" {
+  type        = string
+  default     = ""
+  description = "The name for the Bridgecrew read-only IAM role."
 }


### PR DESCRIPTION
When using the latest version of the module the calculated default
name for the IAM role can get quite lengthy depending on the size of
your AWS account alias name.  A great number of our accounts end up
past the limit of 64 chars by the time the `org_name` and
`account_alias` are prepended.  Example error:

```
│ Error: expected length of name to be in the range (1 - 64), got matillion0-matillion-financial-commitments-read-bridgecrewcwssarole
│
│   with module.bridgecrew-read-only.aws_iam_role.bridgecrew_account_role,
│   on .terraform/modules/bridgecrew-read-only/iam_bridgecrew_role.tf line 2, in resource "aws_iam_role" "bridgecrew_account_role":
│    2:   name               = local.role_name
```

With this change it allows users to optionally set a custom IAM role
name to mitigate this issue or simply allow users to set what they
want inline with their usual role name conventions. If nothing is set
the naming should behave the same as it always has.