### PR TITLE
[Draft] Run null_resource.create_bridgecrew also when the message_template changed

### DIFF
--- a/bridgecrew_sns_resource.tf
+++ b/bridgecrew_sns_resource.tf
@@ -22,6 +22,10 @@ locals {
 }
 
 resource "null_resource" "create_bridgecrew" {
+  triggers = {
+    build = md5(local.message_template)
+  }
+
   provisioner "local-exec" {
     command     = "aws sns ${local.profile_str} --region ${data.aws_region.region.id} publish --target-arn \"${local.bridgecrew_sns_topic}\" --message '${jsonencode(local.message_template)}' && sleep 30"
     working_dir = path.module


### PR DESCRIPTION
※ It's kind of a issue rather than a confident PR

# Problem Summary

When I change `api_token` variable from outside of the module, replace happens on these two resources by the trigger, and the integration remains to be deleted.

- `null_resource.disconnect_bridgecrew`
- `null_resource.update_bridgecrew`

I think `null_resource.create_bridgecrew` should be replaced at the same time, it can create integration again.

# Sequence

## Current sequence

- delete `null_resource.disconnect_bridgecrew` ( bridgecrew integration delete )
- delete `null_resource.update_bridgecrew` ( no effect )
- create `null_resource.disconnect_bridgecrew` ( no effect )
- create `null_resource.update_bridgecrew` ( integration update called but it's already deleted ! )

( Order can be different since there is no dependency between disconnect_bridgecrew and update_bridgecrew, but in any case integration will be deleted before update runs. )

## Future sequence ( with this PR change

- delete `null_resource.disconnect_bridgecrew` ( bridgecrew integration delete )
- delete `null_resource.update_bridgecrew` ( no effect )
- delete `null_resource.create_bridgecrew` ( no effect )
- create `null_resource.create_bridgecrew` ( bridgecrew integration created again )
- create `null_resource.disconnect_bridgecrew` ( no effect )
- create `null_resource.update_bridgecrew` ( no effect )

# Considerations 

- Should I add && sleep 30 on `disconnect_bridgecrew` also for waiting deletion before re-creation ?
- Is there any other way not to call integration deletion but to call only update when api_token changed ? ( If it's possible to avoid deletion it's the best way.)

# Current workaround

- I am using `terraform state rm` to run re-create / not to call disconnect for now. 